### PR TITLE
Revert js from 23.0.1 to 22.3.2

### DIFF
--- a/graphviz-java/pom.xml
+++ b/graphviz-java/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js</artifactId>
-            <version>23.0.1</version>
+            <version>22.3.2</version>
             <optional>true</optional>
         </dependency>
         <!-- Only needed for Javascript Graphviz Engines -->


### PR DESCRIPTION
Reverts Summer2023SHY/graphviz-java#33

Due to an upstream issue (https://github.com/oracle/graal/issues/6831), Graal JS is _not_ compatible with JDK 11+. Thus, this PR reverts the dependency update.